### PR TITLE
Support AI_ADDRCONFIG in  getaddrinfo(3)

### DIFF
--- a/include/netdb.h
+++ b/include/netdb.h
@@ -44,6 +44,7 @@ struct addrinfo {
 #define EAI_NONAME     -2
 #define EAI_AGAIN      -3
 #define EAI_FAIL       -4
+#define EAI_NODATA     -5
 #define EAI_FAMILY     -6
 #define EAI_SOCKTYPE   -7
 #define EAI_SERVICE    -8

--- a/src/network/getaddrinfo.c
+++ b/src/network/getaddrinfo.c
@@ -102,9 +102,11 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			.ai_next = &out[k+1].ai };
 		k++;
 	}
-	if ( nais >= 1 ) {
-		out[nais-1].ai.ai_next = 0;
+	if ( nais < 1 ) {
+		free( out );
+		return EAI_NODATA;
 	}
+	out[nais-1].ai.ai_next = 0;
 	*res = &out->ai;
 	return 0;
 }

--- a/src/network/getaddrinfo.c
+++ b/src/network/getaddrinfo.c
@@ -35,9 +35,7 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			return EAI_BADFLAGS;
 
 		if (flags & AI_ADDRCONFIG) {
-			if (0 != __lookup_addrconfig(&addrconfig)) {
-				return EAI_SYSTEM;
-			}
+			__lookup_addrconfig(&addrconfig);
 		}
 
 		switch (family) {
@@ -88,7 +86,7 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			out[k].sa.sin6.sin6_port = htons(ports[j].port);
 			out[k].sa.sin6.sin6_scope_id = addrs[i].scopeid;
 			memcpy(&out[k].sa.sin6.sin6_addr, &addrs[i].addr, 16);
-			break;			
+			break;
 		}
 		out[k].ai = (struct addrinfo){
 			.ai_family = addrs[i].family,

--- a/src/network/getaddrinfo.c
+++ b/src/network/getaddrinfo.c
@@ -19,6 +19,7 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			struct sockaddr_in6 sin6;
 		} sa;
 	} *out;
+	struct addrconfig addrconfig;
 
 	if (!host && !serv) return EAI_NONAME;
 
@@ -32,6 +33,12 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			AI_V4MAPPED | AI_ALL | AI_ADDRCONFIG | AI_NUMERICSERV;
 		if ((flags & mask) != flags)
 			return EAI_BADFLAGS;
+
+		if (flags & AI_ADDRCONFIG) {
+			if (0 != __lookup_addrconfig(&addrconfig)) {
+				return EAI_SYSTEM;
+			}
+		}
 
 		switch (family) {
 		case AF_INET:
@@ -61,7 +68,28 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 		outcanon = 0;
 	}
 
-	for (k=i=0; i<naddrs; i++) for (j=0; j<nservs; j++, k++) {
+	for (k=i=0; i<naddrs; i++) for (j=0; j<nservs; j++) {
+		switch (addrs[i].family) {
+		case AF_INET:
+			if ((flags & AI_ADDRCONFIG) && !addrconfig.af_inet) {
+				nais--;
+				continue;
+			}
+			out[k].sa.sin.sin_family = AF_INET;
+			out[k].sa.sin.sin_port = htons(ports[j].port);
+			memcpy(&out[k].sa.sin.sin_addr, &addrs[i].addr, 4);
+			break;
+		case AF_INET6:
+			if ((flags & AI_ADDRCONFIG ) && !addrconfig.af_inet6) {
+				nais--;
+				continue;
+			}
+			out[k].sa.sin6.sin6_family = AF_INET6;
+			out[k].sa.sin6.sin6_port = htons(ports[j].port);
+			out[k].sa.sin6.sin6_scope_id = addrs[i].scopeid;
+			memcpy(&out[k].sa.sin6.sin6_addr, &addrs[i].addr, 16);
+			break;			
+		}
 		out[k].ai = (struct addrinfo){
 			.ai_family = addrs[i].family,
 			.ai_socktype = ports[j].socktype,
@@ -72,21 +100,11 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
 			.ai_addr = (void *)&out[k].sa,
 			.ai_canonname = outcanon,
 			.ai_next = &out[k+1].ai };
-		switch (addrs[i].family) {
-		case AF_INET:
-			out[k].sa.sin.sin_family = AF_INET;
-			out[k].sa.sin.sin_port = htons(ports[j].port);
-			memcpy(&out[k].sa.sin.sin_addr, &addrs[i].addr, 4);
-			break;
-		case AF_INET6:
-			out[k].sa.sin6.sin6_family = AF_INET6;
-			out[k].sa.sin6.sin6_port = htons(ports[j].port);
-			out[k].sa.sin6.sin6_scope_id = addrs[i].scopeid;
-			memcpy(&out[k].sa.sin6.sin6_addr, &addrs[i].addr, 16);
-			break;			
-		}
+		k++;
 	}
-	out[nais-1].ai.ai_next = 0;
+	if ( nais >= 1 ) {
+		out[nais-1].ai.ai_next = 0;
+	}
 	*res = &out->ai;
 	return 0;
 }

--- a/src/network/lookup.h
+++ b/src/network/lookup.h
@@ -39,7 +39,7 @@ struct addrconfig {
 int __lookup_serv(struct service buf[static MAXSERVS], const char *name, int proto, int socktype, int flags);
 int __lookup_name(struct address buf[static MAXADDRS], char canon[static 256], const char *name, int family, int flags);
 int __lookup_ipliteral(struct address buf[static 1], const char *name, int family);
-int __lookup_addrconfig( struct addrconfig *cfg );
+void __lookup_addrconfig( struct addrconfig *cfg );
 
 int __get_resolv_conf(struct resolvconf *, char *, size_t);
 

--- a/src/network/lookup.h
+++ b/src/network/lookup.h
@@ -1,6 +1,7 @@
 #ifndef LOOKUP_H
 #define LOOKUP_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
 
@@ -30,9 +31,15 @@ struct resolvconf {
 #define MAXADDRS 48
 #define MAXSERVS 2
 
+struct addrconfig {
+	bool af_inet  : 1;
+	bool af_inet6 : 1;
+};
+
 int __lookup_serv(struct service buf[static MAXSERVS], const char *name, int proto, int socktype, int flags);
 int __lookup_name(struct address buf[static MAXADDRS], char canon[static 256], const char *name, int family, int flags);
 int __lookup_ipliteral(struct address buf[static 1], const char *name, int family);
+int __lookup_addrconfig( struct addrconfig *cfg );
 
 int __get_resolv_conf(struct resolvconf *, char *, size_t);
 

--- a/src/network/lookup_addrconfig.c
+++ b/src/network/lookup_addrconfig.c
@@ -21,13 +21,6 @@ int __lookup_addrconfig( struct addrconfig *cfg ) {
 		!( NULL == it || ( cfg->af_inet && cfg->af_inet6 ) );
 		it = it->ifa_next
 	) {
-#ifdef BE_LIKE_GLIBC
-		if (IFF_LOOPBACK & it->ifa_flags) {
-			// http://man7.org/linux/man-pages/man3/getaddrinfo.3.html
-			// loopback devices do not count as having configured addresses
-			continue;
-		}
-#endif
 		switch(it->ifa_addr->sa_family) {
 		case AF_INET:
 			cfg->af_inet = true;

--- a/src/network/lookup_addrconfig.c
+++ b/src/network/lookup_addrconfig.c
@@ -1,0 +1,44 @@
+#include "lookup.h"
+
+#include <sys/types.h>
+#include <ifaddrs.h>
+#include <netdb.h>
+#define _BSD_SOURCE
+#include <net/if.h>
+
+int __lookup_addrconfig( struct addrconfig *cfg ) {
+	int r;
+	struct ifaddrs *ifap;
+	struct ifaddrs *it;
+
+	r = getifaddrs(&ifap);
+	if ( 0 != r ) {
+		return EAI_SYSTEM;
+	}
+
+	for(
+		cfg->af_inet = false, cfg->af_inet6 = false, it = ifap;
+		!( NULL == it || ( cfg->af_inet && cfg->af_inet6 ) );
+		it = it->ifa_next
+	) {
+		if (IFF_LOOPBACK & it->ifa_flags) {
+			// http://man7.org/linux/man-pages/man3/getaddrinfo.3.html
+			// loopback devices do not count as having configured addresses
+			continue;
+		}
+		switch(it->ifa_addr->sa_family) {
+		case AF_INET:
+			cfg->af_inet = true;
+			break;
+		case AF_INET6:
+			cfg->af_inet6 = true;
+			break;
+		default:
+			continue;
+		}
+	}
+
+	freeifaddrs( ifap );
+
+	return 0;
+}

--- a/src/network/lookup_addrconfig.c
+++ b/src/network/lookup_addrconfig.c
@@ -21,11 +21,13 @@ int __lookup_addrconfig( struct addrconfig *cfg ) {
 		!( NULL == it || ( cfg->af_inet && cfg->af_inet6 ) );
 		it = it->ifa_next
 	) {
+#ifdef BE_LIKE_GLIBC
 		if (IFF_LOOPBACK & it->ifa_flags) {
 			// http://man7.org/linux/man-pages/man3/getaddrinfo.3.html
 			// loopback devices do not count as having configured addresses
 			continue;
 		}
+#endif
 		switch(it->ifa_addr->sa_family) {
 		case AF_INET:
 			cfg->af_inet = true;


### PR DESCRIPTION
Currently, if user code passes in the aforementioned flag, there is no check to see
whether a ~~non-loopback~~ network interface is configured with the specified (or
unspecified) address family before returning results, which is what getaddrinfo(3)
should do according to [1].

As a result of the current behaviour, musl's getaddrinfo(3) would return e.g. "::1"
to user code even when no interfaces (including lo) were configured with IPv6
addresses. I've documented this to some extent here [2].

This change makes musl's getaddrinfo(3) behave according to the POSIX spec w.r.t. AI_ADDRCONFIG, but not like glibc's implementation (which does not count loopback addresses and uses AI_ADDRCONFIG by default).

~~[1] http://man7.org/linux/man-pages/man3/getaddrinfo.3.html~~
[1] http://pubs.opengroup.org/onlinepubs/000095399/functions/freeaddrinfo.html
[2] https://issues.apache.org/jira/browse/THRIFT-4594